### PR TITLE
fixed secret for cookies to prevent worker conflict

### DIFF
--- a/challenges/web/Burger_Converter/challenge.yaml
+++ b/challenges/web/Burger_Converter/challenge.yaml
@@ -1,6 +1,6 @@
 name: "Burger Converter"
 author: "Chris Haller"
 difficulty: "Hard"
-description: "Welcome to the Metric-to-Imperial Conversion Portal! Convert with pride. Submit your own conversions to demonstrate the power of American hegemony through cheeseburger emojis! Don't forget to try the Konami code too!"
+description: "Welcome to the Metric-to-Imperial Conversion Portal! Convert with pride and try to log in as the `admin` user. Submit your own conversions to demonstrate the power of American hegemony through cheeseburger emojis! Don't forget to try the Konami code too!"
 type: "http"
 link: DYNAMIC

--- a/challenges/web/Burger_Converter/src/app.py
+++ b/challenges/web/Burger_Converter/src/app.py
@@ -34,7 +34,7 @@ def create_app():
 
     app = Flask(__name__, static_folder="static", template_folder="templates")
     # Generate a 16-character hexadecimal secret key at server start
-    app.secret_key = secrets.token_hex(16)
+    app.secret_key = os.environ.get("SECRET_KEY", "b30b019b0403192b")
     app.permanent_session_lifetime = timedelta(hours=6)
     app.config.update(SESSION_COOKIE_SAMESITE="None", SESSION_COOKIE_SECURE=True)
 


### PR DESCRIPTION
Added more details to specifically target the `admin` user for the application.

Changed a generated secret to hard-coded. This prevents cookie decryption errors across workers when interacting with the application. 